### PR TITLE
new module: src/event_ledger.rs #2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,7 +363,9 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "sha2",
  "tokio",
+ "zip",
 ]
 
 [[package]]
@@ -407,6 +409,15 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "arboard"
@@ -1209,6 +1220,17 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7068,10 +7090,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap 2.13.0",
+ "memchr",
+ "thiserror 2.0.18",
+ "zopfli",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zune-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,5 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 chrono = "0.4"
 rand = "0.9"
+sha2 = "0.10"
+zip = { version = "2", default-features = false, features = ["deflate"] }

--- a/src/agent_conversation_loop.rs
+++ b/src/agent_conversation_loop.rs
@@ -1,4 +1,5 @@
 use crate::adk_integration::OllamaStopEpoch;
+use crate::event_ledger::EventLedger;
 use crate::http_client::{send_evaluator_result, send_researcher_result};
 use crate::reproducibility::RunContext;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
@@ -15,6 +16,7 @@ pub struct ConversationSidecarConfig {
 
 #[derive(Clone)]
 pub struct SidecarEvaluator {
+    pub global_id: String,
     pub instruction: String,
     pub analysis_mode: String,
     pub limit_token: bool,
@@ -23,6 +25,7 @@ pub struct SidecarEvaluator {
 
 #[derive(Clone)]
 pub struct SidecarResearcher {
+    pub global_id: String,
     pub topic_mode: String,
     pub instruction: String,
     pub limit_token: bool,
@@ -71,8 +74,10 @@ pub async fn run_sidecars_for_message(
     selected_model: Option<&str>,
     ollama_stop_epoch: Option<OllamaStopEpoch>,
     post_http: bool,
+    ledger: Option<&Arc<EventLedger>>,
 ) -> Result<(), ()> {
     for ev in &sidecars.evaluators {
+        let ollama_input = format!("{}\n{}", ev.instruction, agent_message);
         match crate::adk_integration::send_to_ollama(
             ollama_host,
             &ev.instruction,
@@ -85,6 +90,16 @@ pub async fn run_sidecars_for_message(
         .await
         {
             Ok(response) => {
+                if let Some(l) = ledger {
+                    let _ = l.append_with_hashes(
+                        "sidecar.evaluator",
+                        Some(ev.global_id.clone()),
+                        selected_model.map(|s| s.to_string()),
+                        &ollama_input,
+                        &response,
+                        serde_json::json!({ "analysis_mode": ev.analysis_mode }),
+                    );
+                }
                 let sentiment = evaluator_sentiment(ev.analysis_mode.as_str(), &response);
                 if post_http {
                     if let Err(e) = send_evaluator_result(
@@ -93,6 +108,7 @@ pub async fn run_sidecars_for_message(
                         sentiment,
                         &response,
                         run_context,
+                        ledger,
                     )
                     .await
                     {
@@ -103,6 +119,20 @@ pub async fn run_sidecars_for_message(
             Err(e) => {
                 if e.to_string() == crate::adk_integration::OLLAMA_STOPPED_MSG {
                     return Err(());
+                }
+                if let Some(l) = ledger {
+                    let _ = l.append_with_hashes(
+                        "sidecar.evaluator",
+                        Some(ev.global_id.clone()),
+                        selected_model.map(|s| s.to_string()),
+                        &ollama_input,
+                        "",
+                        serde_json::json!({
+                            "analysis_mode": ev.analysis_mode,
+                            "stage": "ollama",
+                            "error": e.to_string(),
+                        }),
+                    );
                 }
                 eprintln!("[Evaluator] Ollama error: {}", e);
             }
@@ -120,6 +150,7 @@ pub async fn run_sidecars_for_message(
             rs.instruction,
             topic.to_lowercase()
         );
+        let ollama_input = format!("{}\n{}", instruction, agent_message);
         match crate::adk_integration::send_to_ollama(
             ollama_host,
             &instruction,
@@ -132,6 +163,16 @@ pub async fn run_sidecars_for_message(
         .await
         {
             Ok(response) => {
+                if let Some(l) = ledger {
+                    let _ = l.append_with_hashes(
+                        "sidecar.researcher",
+                        Some(rs.global_id.clone()),
+                        selected_model.map(|s| s.to_string()),
+                        &ollama_input,
+                        &response,
+                        serde_json::json!({ "topic": topic }),
+                    );
+                }
                 if post_http {
                     if let Err(e) = send_researcher_result(
                         endpoint,
@@ -139,6 +180,7 @@ pub async fn run_sidecars_for_message(
                         &topic,
                         &response,
                         run_context,
+                        ledger,
                     )
                     .await
                     {
@@ -149,6 +191,20 @@ pub async fn run_sidecars_for_message(
             Err(e) => {
                 if e.to_string() == crate::adk_integration::OLLAMA_STOPPED_MSG {
                     return Err(());
+                }
+                if let Some(l) = ledger {
+                    let _ = l.append_with_hashes(
+                        "sidecar.researcher",
+                        Some(rs.global_id.clone()),
+                        selected_model.map(|s| s.to_string()),
+                        &ollama_input,
+                        "",
+                        serde_json::json!({
+                            "topic": topic,
+                            "stage": "ollama",
+                            "error": e.to_string(),
+                        }),
+                    );
                 }
                 eprintln!("[Researcher] Ollama error: {}", e);
             }
@@ -235,11 +291,13 @@ pub async fn start_conversation_loop(
     agent_a_instruction: String,
     agent_a_topic: String,
     agent_a_topic_source: String,
+    agent_a_global_id: String,
     agent_b_id: usize,
     agent_b_name: String,
     agent_b_instruction: String,
     agent_b_topic: String,
     agent_b_topic_source: String,
+    agent_b_global_id: String,
     ollama_host: String,
     endpoint: String,
     active_flag: Arc<Mutex<bool>>,
@@ -253,6 +311,7 @@ pub async fn start_conversation_loop(
     run_generation_counter: Arc<AtomicU64>,
     loops_remaining_in_run: Arc<AtomicUsize>,
     conversation_graph_running: Arc<AtomicBool>,
+    ledger: Option<Arc<EventLedger>>,
 ) {
     let mut turn = 0;
     let mut is_agent_a_turn = true;
@@ -274,6 +333,17 @@ pub async fn start_conversation_loop(
     );
     println!("\n{}", start_message);
 
+    if let Some(ref l) = ledger {
+        let _ = l.append_with_hashes(
+            "dialogue.start",
+            None,
+            selected_model.clone(),
+            "",
+            &start_message,
+            serde_json::json!({ "topics_summary": topics_summary }),
+        );
+    }
+
     // Send to chat app (await so later lines follow this in order).
     if let Err(e) = crate::http_client::send_conversation_message(
         &endpoint,
@@ -284,6 +354,7 @@ pub async fn start_conversation_loop(
         &topics_summary,
         &start_message,
         run_context.as_ref(),
+        ledger.as_ref(),
     )
     .await
     {
@@ -355,11 +426,11 @@ pub async fn start_conversation_loop(
         let turn_message = format!("Turn {}: {} -> {}", turn + 1, sender_name, receiver_name);
         println!("{}", turn_message);
 
-        // Send turn message to chat app
         let endpoint_clone = endpoint.clone();
         let topic_clone = effective_topic.clone();
         let turn_message_clone = turn_message.clone();
         let run_context_for_turn = run_context.clone();
+        let ledger_turn = ledger.clone();
         tokio::spawn(async move {
             if let Err(e) = crate::http_client::send_conversation_message(
                 &endpoint_clone,
@@ -370,6 +441,7 @@ pub async fn start_conversation_loop(
                 &topic_clone,
                 &turn_message_clone,
                 run_context_for_turn.as_ref(),
+                ledger_turn.as_ref(),
             )
             .await
             {
@@ -378,6 +450,7 @@ pub async fn start_conversation_loop(
         });
 
         // Send message to Ollama
+        let dialogue_input = format!("{}\n---\n{}", enhanced_instruction, conversation_context);
         match crate::adk_integration::send_to_ollama_with_context(
             ollama_host.as_str(),
             &enhanced_instruction,
@@ -390,6 +463,24 @@ pub async fn start_conversation_loop(
         .await
         {
             Ok(response) => {
+                let sender_gid = if sender_id == agent_a_id {
+                    agent_a_global_id.clone()
+                } else {
+                    agent_b_global_id.clone()
+                };
+                if let Some(ref l) = ledger {
+                    let _ = l.append_with_hashes(
+                        "dialogue.turn",
+                        Some(sender_gid),
+                        selected_model.clone(),
+                        &dialogue_input,
+                        &response,
+                        serde_json::json!({
+                            "turn": turn,
+                            "receiver_name": receiver_name,
+                        }),
+                    );
+                }
                 // Add to history
                 history.add_message(sender_id, sender_name.clone(), response.clone(), turn);
                 // Include a monotonic turn marker so downstream nodes can react
@@ -414,6 +505,7 @@ pub async fn start_conversation_loop(
                     &effective_topic,
                     &response,
                     run_context.as_ref(),
+                    ledger.as_ref(),
                 )
                 .await
                 {
@@ -430,6 +522,7 @@ pub async fn start_conversation_loop(
                     selected_model.as_deref(),
                     ollama_stop_epoch.clone(),
                     true,
+                    ledger.as_ref(),
                 )
                 .await
                 .is_err()
@@ -444,6 +537,16 @@ pub async fn start_conversation_loop(
             Err(e) => {
                 if e.to_string() == crate::adk_integration::OLLAMA_STOPPED_MSG {
                     break;
+                }
+                if let Some(ref l) = ledger {
+                    let _ = l.append_with_hashes(
+                        "dialogue.ollama_error",
+                        None,
+                        selected_model.clone(),
+                        &dialogue_input,
+                        "",
+                        serde_json::json!({ "error": e.to_string(), "turn": turn }),
+                    );
                 }
                 eprintln!("[Error] Ollama error in conversation loop: {}", e);
                 break;
@@ -468,6 +571,17 @@ pub async fn start_conversation_loop(
     );
     println!("\n{}", end_message);
 
+    if let Some(ref l) = ledger {
+        let _ = l.append_with_hashes(
+            "dialogue.end",
+            None,
+            selected_model.clone(),
+            "",
+            &end_message,
+            serde_json::json!({ "total_turns": turn }),
+        );
+    }
+
     // End line after all turns and their sidecars; await so nothing is still in flight here.
     if let Err(e) = crate::http_client::send_conversation_message(
         &endpoint,
@@ -478,6 +592,7 @@ pub async fn start_conversation_loop(
         &topics_summary,
         &end_message,
         run_context.as_ref(),
+        ledger.as_ref(),
     )
     .await
     {
@@ -487,5 +602,8 @@ pub async fn start_conversation_loop(
     let prev_remaining = loops_remaining_in_run.fetch_sub(1, Ordering::SeqCst);
     if prev_remaining == 1 && run_generation_counter.load(Ordering::SeqCst) == run_generation {
         conversation_graph_running.store(false, Ordering::Release);
+        if let Some(ref l) = ledger {
+            let _ = l.try_finalize_run_stopped("conversation_loops_finished");
+        }
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,5 @@
 use crate::agent_entities::{Agent, AgentManager, Evaluator, Researcher};
+use crate::event_ledger::EventLedger;
 use crate::reproducibility::{RunContext, RunManifest};
 use eframe::egui;
 use std::sync::atomic::{AtomicBool, AtomicU64};
@@ -40,6 +41,10 @@ pub struct AMSAgents {
     manifest_import_path: String,
     /// JSON path for Agents tab Load / Save (graph + runtime).
     agents_workspace_path: String,
+    /// Target path for "Download Run Bundle" (zip).
+    pub(super) bundle_export_path: String,
+    /// Append-only ledger for the active run (`events.jsonl`), if any.
+    pub(super) event_ledger: Option<Arc<EventLedger>>,
     manifest_status_message: String,
     read_only_replay_mode: bool,
     /// True while a started play is active (cleared on Stop or when all conversation tasks finish).
@@ -87,6 +92,8 @@ impl AMSAgents {
             manifest_export_path: "runs/exported-manifest.json".to_string(),
             manifest_import_path: "runs/import-manifest.json".to_string(),
             agents_workspace_path: "runs/agents-workspace.json".to_string(),
+            bundle_export_path: "runs/run-bundle.zip".to_string(),
+            event_ledger: None,
             manifest_status_message: String::new(),
             read_only_replay_mode: false,
             conversation_graph_running: Arc::new(AtomicBool::new(false)),

--- a/src/app/nodes_panel.rs
+++ b/src/app/nodes_panel.rs
@@ -1,4 +1,5 @@
 use super::AMSAgents;
+use crate::event_ledger::EventLedger;
 use crate::reproducibility::{
     APP_NAME, GraphSnapshot, MANIFEST_VERSION, ManifestEdge, ManifestNode, RunContext, RunManifest,
     RunRuntimeSettings, canonical_graph_signature, derive_experiment_id, export_manifest_to,
@@ -1180,6 +1181,7 @@ fn build_conversation_sidecar_from_agents(
         match &r.data.payload {
             NodePayload::Evaluator(e) if e.active => {
                 evaluators.push(SidecarEvaluator {
+                    global_id: e.global_id.clone(),
                     instruction: e.instruction.clone(),
                     analysis_mode: e.analysis_mode.clone(),
                     limit_token: e.limit_token,
@@ -1188,6 +1190,7 @@ fn build_conversation_sidecar_from_agents(
             }
             NodePayload::Researcher(res) if res.active => {
                 researchers.push(SidecarResearcher {
+                    global_id: res.global_id.clone(),
                     topic_mode: res.topic_mode.clone(),
                     instruction: res.instruction.clone(),
                     limit_token: res.limit_token,
@@ -1638,12 +1641,32 @@ impl AMSAgents {
         Ok(())
     }
 
+    /// Writes `manifest.json`, `events.jsonl`, and `summary.json` from the current run into a zip.
+    pub(super) fn download_run_bundle_to_path(&mut self, zip_path: PathBuf) -> anyhow::Result<()> {
+        let ctx = self.current_run_context.as_ref().ok_or_else(|| {
+            anyhow::anyhow!(
+                "no active run context; start the graph or load a manifest with a run id"
+            )
+        })?;
+        let run_dir =
+            crate::reproducibility::run_dir(&runs_root(), &ctx.experiment_id, &ctx.run_id);
+        if !run_dir.is_dir() {
+            anyhow::bail!("run directory not found: {}", run_dir.display());
+        }
+        crate::event_ledger::write_run_bundle_zip(&run_dir, &zip_path)?;
+        self.manifest_status_message = format!("Run bundle written: {}", zip_path.display());
+        Ok(())
+    }
+
     fn stop_graph(&mut self) {
         self.ollama_run_epoch.fetch_add(1, Ordering::SeqCst);
         for (_, flag, _) in &self.conversation_loop_handles {
             *flag.lock().unwrap() = false;
         }
         self.conversation_loop_handles.clear();
+        if let Some(ledger) = self.event_ledger.take() {
+            let _ = ledger.try_finalize_run_stopped("graph_stopped");
+        }
         self.conversation_graph_running
             .store(false, Ordering::Release);
         *self.last_message_in_chat.lock().unwrap() = None;
@@ -1693,10 +1716,35 @@ impl AMSAgents {
                     return false;
                 }
             };
-        if let Err(e) = self.persist_active_manifest(manifest) {
-            self.manifest_status_message = format!("Manifest save failed: {e}");
-            eprintln!("[Run Graph] Manifest save failed: {e}");
-            return false;
+        let manifest_path = match self.persist_active_manifest(manifest) {
+            Ok(p) => p,
+            Err(e) => {
+                self.manifest_status_message = format!("Manifest save failed: {e}");
+                eprintln!("[Run Graph] Manifest save failed: {e}");
+                return false;
+            }
+        };
+
+        if let Some(ctx) = self.current_run_context.as_ref() {
+            let run_dir = manifest_path
+                .parent()
+                .map(|p| p.to_path_buf())
+                .unwrap_or_else(|| runs_root().join(&ctx.experiment_id).join(&ctx.run_id));
+            match EventLedger::open(run_dir, ctx.experiment_id.clone(), ctx.run_id.clone()) {
+                Ok(ledger) => {
+                    let arc = Arc::new(ledger);
+                    if let Err(e) = arc.append_system_run_started(&manifest_path) {
+                        self.manifest_status_message = format!("Ledger start failed: {e}");
+                        eprintln!("[Run Graph] Ledger start failed: {e}");
+                    } else {
+                        self.event_ledger = Some(arc);
+                    }
+                }
+                Err(e) => {
+                    self.manifest_status_message = format!("Ledger open failed: {e}");
+                    eprintln!("[Run Graph] Ledger open failed: {e}");
+                }
+            }
         }
 
         sync_evaluator_researcher_activity(&mut self.nodes_panel.agents);
@@ -1739,6 +1787,9 @@ impl AMSAgents {
             match serde_json::to_string_pretty(&play_plan) {
                 Ok(json) => println!("[Run Graph] play plan:\n{}", json),
                 Err(e) => eprintln!("[Run Graph] failed to serialize play plan: {e}"),
+            }
+            if let Some(ref l) = self.event_ledger {
+                let _ = l.try_finalize_run_stopped("no_eligible_conversation_workers");
             }
             return true;
         }
@@ -1928,6 +1979,34 @@ impl AMSAgents {
         let ollama_caught = self.ollama_run_epoch.load(Ordering::SeqCst);
         let ollama_stop_epoch = Some((ollama_epoch, ollama_caught));
 
+        let agent_a_global_id = self
+            .nodes_panel
+            .agents
+            .iter()
+            .find(|r| r.id == agent_a_id)
+            .and_then(|r| {
+                if let NodePayload::Worker(w) = &r.data.payload {
+                    Some(w.global_id.clone())
+                } else {
+                    None
+                }
+            })
+            .unwrap_or_default();
+        let agent_b_global_id = self
+            .nodes_panel
+            .agents
+            .iter()
+            .find(|r| r.id == agent_b_id)
+            .and_then(|r| {
+                if let NodePayload::Worker(w) = &r.data.payload {
+                    Some(w.global_id.clone())
+                } else {
+                    None
+                }
+            })
+            .unwrap_or_default();
+        let ledger = self.event_ledger.clone();
+
         let loop_handle = handle.spawn(async move {
             crate::agent_conversation_loop::start_conversation_loop(
                 message_event_source_id,
@@ -1938,11 +2017,13 @@ impl AMSAgents {
                 agent_a_instruction,
                 agent_a_topic,
                 agent_a_topic_source,
+                agent_a_global_id,
                 agent_b_id,
                 agent_b_name,
                 agent_b_instruction,
                 agent_b_topic,
                 agent_b_topic_source,
+                agent_b_global_id,
                 ollama_host,
                 endpoint,
                 flag_clone,
@@ -1956,6 +2037,7 @@ impl AMSAgents {
                 run_generation_counter,
                 loops_remaining_in_run,
                 conversation_graph_running_flag,
+                ledger,
             )
             .await;
         });
@@ -2347,7 +2429,10 @@ impl AMSAgents {
                         };
                         let epoch_arc = self.ollama_run_epoch.clone();
                         let epoch_caught = self.ollama_run_epoch.load(Ordering::SeqCst);
+                        let ledger = self.event_ledger.clone();
+                        let eval_global_id = e.global_id.clone();
                         handle.spawn(async move {
+                            let ollama_in = format!("{}\n{}", instruction, message);
                             match crate::adk_integration::send_to_ollama(
                                 ollama_host.as_str(),
                                 &instruction,
@@ -2360,6 +2445,16 @@ impl AMSAgents {
                             .await
                             {
                                 Ok(response) => {
+                                    if let Some(ref l) = ledger {
+                                        let _ = l.append_with_hashes(
+                                            "sidecar.evaluator",
+                                            Some(eval_global_id.clone()),
+                                            selected_model.clone(),
+                                            &ollama_in,
+                                            &response,
+                                            serde_json::json!({ "analysis_mode": analysis_mode }),
+                                        );
+                                    }
                                     let response_lower = response.to_lowercase();
                                     let sentiment = match analysis_mode.as_str() {
                                         "Topic Extraction" => "topic",
@@ -2399,6 +2494,7 @@ impl AMSAgents {
                                                 sentiment,
                                                 &response,
                                                 run_context.as_ref(),
+                                                ledger.as_ref(),
                                             )
                                             .await
                                         {
@@ -2412,6 +2508,20 @@ impl AMSAgents {
                                 Err(e) => {
                                     if e.to_string() != crate::adk_integration::OLLAMA_STOPPED_MSG
                                     {
+                                        if let Some(ref l) = ledger {
+                                            let _ = l.append_with_hashes(
+                                                "sidecar.evaluator",
+                                                Some(eval_global_id.clone()),
+                                                selected_model.clone(),
+                                                &ollama_in,
+                                                "",
+                                                serde_json::json!({
+                                                    "analysis_mode": analysis_mode,
+                                                    "stage": "ollama",
+                                                    "error": e.to_string(),
+                                                }),
+                                            );
+                                        }
                                         eprintln!("[Evaluator] Ollama error: {}", e);
                                     }
                                 }
@@ -2472,7 +2582,10 @@ impl AMSAgents {
                         };
                         let epoch_arc = self.ollama_run_epoch.clone();
                         let epoch_caught = self.ollama_run_epoch.load(Ordering::SeqCst);
+                        let ledger = self.event_ledger.clone();
+                        let res_global_id = r.global_id.clone();
                         handle.spawn(async move {
+                            let ollama_in = format!("{}\n{}", instruction, message);
                             match crate::adk_integration::send_to_ollama(
                                 ollama_host.as_str(),
                                 &instruction,
@@ -2485,6 +2598,16 @@ impl AMSAgents {
                             .await
                             {
                                 Ok(response) => {
+                                    if let Some(ref l) = ledger {
+                                        let _ = l.append_with_hashes(
+                                            "sidecar.researcher",
+                                            Some(res_global_id.clone()),
+                                            selected_model.clone(),
+                                            &ollama_in,
+                                            &response,
+                                            serde_json::json!({ "topic": topic }),
+                                        );
+                                    }
                                     if has_output_nodes {
                                         if let Err(e) =
                                             crate::http_client::send_researcher_result(
@@ -2493,6 +2616,7 @@ impl AMSAgents {
                                                 &topic,
                                                 &response,
                                                 run_context.as_ref(),
+                                                ledger.as_ref(),
                                             )
                                             .await
                                         {
@@ -2507,6 +2631,20 @@ impl AMSAgents {
                                     if e.to_string()
                                         != crate::adk_integration::OLLAMA_STOPPED_MSG
                                     {
+                                        if let Some(ref l) = ledger {
+                                            let _ = l.append_with_hashes(
+                                                "sidecar.researcher",
+                                                Some(res_global_id.clone()),
+                                                selected_model.clone(),
+                                                &ollama_in,
+                                                "",
+                                                serde_json::json!({
+                                                    "topic": topic,
+                                                    "stage": "ollama",
+                                                    "error": e.to_string(),
+                                                }),
+                                            );
+                                        }
                                         eprintln!("[Researcher] Ollama error: {}", e);
                                     }
                                 }

--- a/src/app/settings_panel.rs
+++ b/src/app/settings_panel.rs
@@ -161,6 +161,24 @@ impl AMSAgents {
                     }
                 }
             });
+            ui.horizontal(|ui| {
+                ui.label("Run bundle (zip) path:");
+                ui.add(
+                    egui::TextEdit::singleline(&mut self.bundle_export_path).desired_width(300.0),
+                );
+                if ui
+                    .button("Download Run Bundle")
+                    .on_hover_text(
+                        "Zip manifest.json, events.jsonl, and summary.json for the current run.",
+                    )
+                    .clicked()
+                {
+                    let p = PathBuf::from(self.bundle_export_path.trim());
+                    if let Err(e) = self.download_run_bundle_to_path(p) {
+                        self.manifest_status_message = format!("Run bundle failed: {e}");
+                    }
+                }
+            });
             if !self.manifest_status_message.trim().is_empty() {
                 ui.label(&self.manifest_status_message);
             }

--- a/src/event_ledger.rs
+++ b/src/event_ledger.rs
@@ -1,0 +1,338 @@
+//! Append-only JSONL event ledger per run (`events.jsonl`) for offline audit and reproducibility.
+//!
+//! Paired with `manifest.json` under `runs/<experiment_id>/<run_id>/`. See GitHub issue #2.
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::fs::{self, File, OpenOptions};
+use std::io::{BufWriter, Write};
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+use crate::reproducibility::now_rfc3339_utc;
+
+pub const EVENTS_FILE: &str = "events.jsonl";
+pub const SUMMARY_FILE: &str = "summary.json";
+pub const BUNDLE_VERSION: &str = "1";
+
+/// Stable SHA-256 hex digest of UTF-8 text (empty string if `data` is empty).
+pub fn sha256_hex(data: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(data.as_bytes());
+    hex_lower(&hasher.finalize())
+}
+
+fn hex_lower(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{:02x}", b)).collect()
+}
+
+fn file_sha256_hex(path: &Path) -> Result<String> {
+    let raw = fs::read(path).with_context(|| format!("read {}", path.display()))?;
+    let mut hasher = Sha256::new();
+    hasher.update(&raw);
+    Ok(hex_lower(&hasher.finalize()))
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EventEnvelope {
+    pub experiment_id: String,
+    pub run_id: String,
+    pub event_id: u64,
+    pub event_type: String,
+    pub timestamp: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub node_global_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    pub input_hash: String,
+    pub output_hash: String,
+    pub payload: serde_json::Value,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RunSummary {
+    pub bundle_version: String,
+    pub experiment_id: String,
+    pub run_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub manifest_sha256: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub events_sha256: Option<String>,
+    pub event_counts: HashMap<String, u64>,
+    pub total_events: u64,
+    pub transport_http_ok: u64,
+    pub transport_http_failed: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub first_timestamp: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_timestamp: Option<String>,
+}
+
+struct EventLedgerState {
+    writer: BufWriter<File>,
+    counts: HashMap<String, u64>,
+    transport_ok: u64,
+    transport_failed: u64,
+    first_timestamp: Option<String>,
+    last_timestamp: Option<String>,
+}
+
+/// Thread-safe append-only ledger for a single run directory.
+pub struct EventLedger {
+    run_dir: PathBuf,
+    experiment_id: String,
+    run_id: String,
+    seq: AtomicU64,
+    /// Ensures `system.run_stopped` + summary are written at most once per run.
+    finalized: AtomicBool,
+    state: Mutex<EventLedgerState>,
+}
+
+impl EventLedger {
+    /// Opens or creates `events.jsonl` in `run_dir` and starts a fresh sequence (new process run).
+    pub fn open(run_dir: PathBuf, experiment_id: String, run_id: String) -> Result<Self> {
+        fs::create_dir_all(&run_dir)
+            .with_context(|| format!("create run dir {}", run_dir.display()))?;
+        let path = run_dir.join(EVENTS_FILE);
+        let file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .with_context(|| format!("open ledger {}", path.display()))?;
+        Ok(Self {
+            run_dir,
+            experiment_id,
+            run_id,
+            seq: AtomicU64::new(0),
+            finalized: AtomicBool::new(false),
+            state: Mutex::new(EventLedgerState {
+                writer: BufWriter::new(file),
+                counts: HashMap::new(),
+                transport_ok: 0,
+                transport_failed: 0,
+                first_timestamp: None,
+                last_timestamp: None,
+            }),
+        })
+    }
+
+    pub fn run_dir(&self) -> &Path {
+        &self.run_dir
+    }
+
+    fn next_id(&self) -> u64 {
+        self.seq.fetch_add(1, Ordering::SeqCst) + 1
+    }
+
+    fn touch_timestamps(state: &mut EventLedgerState, ts: &str) {
+        if state.first_timestamp.is_none() {
+            state.first_timestamp = Some(ts.to_string());
+        }
+        state.last_timestamp = Some(ts.to_string());
+    }
+
+    /// Append a fully specified envelope (hashes precomputed).
+    pub fn append_envelope(
+        &self,
+        event_type: &str,
+        node_global_id: Option<String>,
+        model: Option<String>,
+        input_hash: String,
+        output_hash: String,
+        payload: serde_json::Value,
+    ) -> Result<u64> {
+        let event_id = self.next_id();
+        let timestamp = now_rfc3339_utc();
+        let envelope = EventEnvelope {
+            experiment_id: self.experiment_id.clone(),
+            run_id: self.run_id.clone(),
+            event_id,
+            event_type: event_type.to_string(),
+            timestamp: timestamp.clone(),
+            node_global_id,
+            model,
+            input_hash,
+            output_hash,
+            payload,
+        };
+        let line = serde_json::to_string(&envelope).context("serialize ledger event")?;
+        let mut g = self.state.lock().unwrap();
+        writeln!(g.writer, "{}", line).context("write ledger line")?;
+        g.writer.flush().ok();
+        *g.counts.entry(event_type.to_string()).or_insert(0) += 1;
+        Self::touch_timestamps(&mut g, &timestamp);
+        Ok(event_id)
+    }
+
+    /// Convenience: hash `input` and `output` strings for the envelope.
+    pub fn append_with_hashes(
+        &self,
+        event_type: &str,
+        node_global_id: Option<String>,
+        model: Option<String>,
+        input: &str,
+        output: &str,
+        payload: serde_json::Value,
+    ) -> Result<u64> {
+        self.append_envelope(
+            event_type,
+            node_global_id,
+            model,
+            sha256_hex(input),
+            sha256_hex(output),
+            payload,
+        )
+    }
+
+    pub fn append_transport_http(
+        &self,
+        kind: &str,
+        input_body: &str,
+        response_summary: &str,
+        http_status: Option<u16>,
+        err: Option<&str>,
+    ) -> Result<u64> {
+        let ok = err.is_none() && http_status.map(|s| s < 400).unwrap_or(false);
+        let mut g = self.state.lock().unwrap();
+        if ok {
+            g.transport_ok += 1;
+        } else {
+            g.transport_failed += 1;
+        }
+        drop(g);
+
+        let payload = serde_json::json!({
+            "kind": kind,
+            "http_status": http_status,
+            "outcome": if ok { "ok" } else { "failed" },
+            "error": err,
+        });
+        self.append_envelope(
+            "transport.http",
+            None,
+            None,
+            sha256_hex(input_body),
+            sha256_hex(response_summary),
+            payload,
+        )
+    }
+
+    pub fn append_system_run_started(&self, manifest_path: &Path) -> Result<u64> {
+        let payload = serde_json::json!({
+            "manifest_path": manifest_path.display().to_string(),
+        });
+        self.append_with_hashes("system.run_started", None, None, "", "", payload)
+    }
+
+    pub fn append_system_run_stopped(&self, reason: &str) -> Result<u64> {
+        let payload = serde_json::json!({ "reason": reason });
+        self.append_with_hashes("system.run_stopped", None, None, "", reason, payload)
+    }
+
+    /// Writes `system.run_stopped`, `summary.json`, and flushes — no-op if already finalized.
+    pub fn try_finalize_run_stopped(&self, reason: &str) -> Result<()> {
+        if self
+            .finalized
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_err()
+        {
+            return Ok(());
+        }
+        self.append_system_run_stopped(reason)?;
+        self.write_summary()?;
+        self.flush()?;
+        Ok(())
+    }
+
+    /// Writes `summary.json` next to `events.jsonl` and returns the written path.
+    pub fn write_summary(&self) -> Result<PathBuf> {
+        let manifest_file = self.run_dir.join("manifest.json");
+        let events_file = self.run_dir.join(EVENTS_FILE);
+
+        let manifest_sha256 = if manifest_file.is_file() {
+            Some(file_sha256_hex(&manifest_file)?)
+        } else {
+            None
+        };
+        let events_sha256 = if events_file.is_file() {
+            Some(file_sha256_hex(&events_file)?)
+        } else {
+            None
+        };
+
+        let g = self.state.lock().unwrap();
+        let total_events: u64 = g.counts.values().sum();
+        let summary = RunSummary {
+            bundle_version: BUNDLE_VERSION.to_string(),
+            experiment_id: self.experiment_id.clone(),
+            run_id: self.run_id.clone(),
+            manifest_sha256,
+            events_sha256,
+            event_counts: g.counts.clone(),
+            total_events,
+            transport_http_ok: g.transport_ok,
+            transport_http_failed: g.transport_failed,
+            first_timestamp: g.first_timestamp.clone(),
+            last_timestamp: g.last_timestamp.clone(),
+        };
+        drop(g);
+
+        let path = self.run_dir.join(SUMMARY_FILE);
+        let json = serde_json::to_string_pretty(&summary).context("serialize summary")?;
+        fs::write(&path, json).with_context(|| format!("write {}", path.display()))?;
+        Ok(path)
+    }
+
+    pub fn flush(&self) -> Result<()> {
+        let mut g = self.state.lock().unwrap();
+        g.writer.flush().context("flush ledger")?;
+        Ok(())
+    }
+}
+
+/// Zip `manifest.json`, `events.jsonl`, and `summary.json` from `run_dir` into `zip_path`.
+pub fn write_run_bundle_zip(run_dir: &Path, zip_path: &Path) -> Result<()> {
+    if let Some(parent) = zip_path.parent() {
+        fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
+    }
+    let file =
+        fs::File::create(zip_path).with_context(|| format!("create zip {}", zip_path.display()))?;
+    let mut zip = zip::ZipWriter::new(file);
+    let options = zip::write::SimpleFileOptions::default()
+        .compression_method(zip::CompressionMethod::Deflated);
+
+    for (arc_name, disk_name) in [
+        ("manifest.json", "manifest.json"),
+        (EVENTS_FILE, EVENTS_FILE),
+        (SUMMARY_FILE, SUMMARY_FILE),
+    ] {
+        let p = run_dir.join(disk_name);
+        if !p.is_file() {
+            continue;
+        }
+        let bytes = fs::read(&p).with_context(|| format!("read {}", p.display()))?;
+        zip.start_file(arc_name, options)
+            .with_context(|| format!("zip start {}", arc_name))?;
+        use std::io::Write as _;
+        zip.write_all(&bytes)
+            .with_context(|| format!("zip write {}", arc_name))?;
+    }
+    zip.finish().context("zip finish")?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sha256_empty_string() {
+        assert_eq!(
+            sha256_hex(""),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    }
+}

--- a/src/http_client.rs
+++ b/src/http_client.rs
@@ -1,6 +1,7 @@
+use crate::event_ledger::EventLedger;
 use crate::reproducibility::RunContext;
 use serde::{Deserialize, Serialize};
-use std::sync::{Mutex, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 static OUTGOING_HTTP_LOG: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
@@ -56,6 +57,7 @@ pub async fn send_conversation_message(
     topic: &str,
     message: &str,
     run_context: Option<&RunContext>,
+    ledger: Option<&Arc<EventLedger>>,
 ) -> Result<(), anyhow::Error> {
     let timestamp = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -79,6 +81,8 @@ pub async fn send_conversation_message(
         manifest_version: run_context.map(|c| c.manifest_version.clone()),
     };
 
+    let payload_json = serde_json::to_string(&payload)?;
+
     push_outgoing_http_log_line(format!(
         "POST {} | conversation | {} -> {} | {}",
         endpoint,
@@ -88,10 +92,42 @@ pub async fn send_conversation_message(
     ));
 
     let client = reqwest::Client::new();
-    let response = client.post(endpoint).json(&payload).send().await?;
+    let response = match client.post(endpoint).json(&payload).send().await {
+        Ok(r) => r,
+        Err(e) => {
+            if let Some(l) = ledger {
+                let _ = l.append_transport_http(
+                    "conversation",
+                    &payload_json,
+                    &e.to_string(),
+                    None,
+                    Some(&e.to_string()),
+                );
+            }
+            return Err(anyhow::anyhow!(e));
+        }
+    };
+    let status = response.status();
+    let code = status.as_u16();
+    let body_text = response.text().await.unwrap_or_default();
 
-    if !response.status().is_success() {
-        eprintln!("HTTP request failed: {}", response.status());
+    if let Some(l) = ledger {
+        let err = if status.is_success() {
+            None
+        } else {
+            Some(format!("HTTP {}", code))
+        };
+        let _ = l.append_transport_http(
+            "conversation",
+            &payload_json,
+            &body_text,
+            Some(code),
+            err.as_deref(),
+        );
+    }
+
+    if !status.is_success() {
+        anyhow::bail!("conversation HTTP {}: {}", code, trim_line(&body_text, 200));
     }
 
     Ok(())
@@ -114,6 +150,7 @@ pub async fn send_evaluator_result(
     sentiment: &str,
     message: &str,
     run_context: Option<&RunContext>,
+    ledger: Option<&Arc<EventLedger>>,
 ) -> Result<(), anyhow::Error> {
     let timestamp = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -131,6 +168,8 @@ pub async fn send_evaluator_result(
         run_id: run_context.map(|c| c.run_id.clone()),
         manifest_version: run_context.map(|c| c.manifest_version.clone()),
     };
+    let payload_json = serde_json::to_string(&payload)?;
+
     push_outgoing_http_log_line(format!(
         "POST {} | evaluator {} [{}] | {}",
         endpoint,
@@ -139,9 +178,42 @@ pub async fn send_evaluator_result(
         trim_line(message, 90),
     ));
     let client = reqwest::Client::new();
-    let response = client.post(endpoint).json(&payload).send().await?;
-    if !response.status().is_success() {
-        eprintln!("HTTP evaluator request failed: {}", response.status());
+    let response = match client.post(endpoint).json(&payload).send().await {
+        Ok(r) => r,
+        Err(e) => {
+            if let Some(l) = ledger {
+                let _ = l.append_transport_http(
+                    "evaluator",
+                    &payload_json,
+                    &e.to_string(),
+                    None,
+                    Some(&e.to_string()),
+                );
+            }
+            return Err(anyhow::anyhow!(e));
+        }
+    };
+    let status = response.status();
+    let code = status.as_u16();
+    let body_text = response.text().await.unwrap_or_default();
+
+    if let Some(l) = ledger {
+        let err = if status.is_success() {
+            None
+        } else {
+            Some(format!("HTTP {}", code))
+        };
+        let _ = l.append_transport_http(
+            "evaluator",
+            &payload_json,
+            &body_text,
+            Some(code),
+            err.as_deref(),
+        );
+    }
+
+    if !status.is_success() {
+        anyhow::bail!("evaluator HTTP {}: {}", code, trim_line(&body_text, 200));
     }
     Ok(())
 }
@@ -152,6 +224,7 @@ pub async fn send_researcher_result(
     topic: &str,
     message: &str,
     run_context: Option<&RunContext>,
+    ledger: Option<&Arc<EventLedger>>,
 ) -> Result<(), anyhow::Error> {
     let timestamp = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -169,6 +242,8 @@ pub async fn send_researcher_result(
         run_id: run_context.map(|c| c.run_id.clone()),
         manifest_version: run_context.map(|c| c.manifest_version.clone()),
     };
+    let payload_json = serde_json::to_string(&payload)?;
+
     push_outgoing_http_log_line(format!(
         "POST {} | researcher {} [{}] | {}",
         endpoint,
@@ -177,9 +252,42 @@ pub async fn send_researcher_result(
         trim_line(message, 90),
     ));
     let client = reqwest::Client::new();
-    let response = client.post(endpoint).json(&payload).send().await?;
-    if !response.status().is_success() {
-        eprintln!("HTTP researcher request failed: {}", response.status());
+    let response = match client.post(endpoint).json(&payload).send().await {
+        Ok(r) => r,
+        Err(e) => {
+            if let Some(l) = ledger {
+                let _ = l.append_transport_http(
+                    "researcher",
+                    &payload_json,
+                    &e.to_string(),
+                    None,
+                    Some(&e.to_string()),
+                );
+            }
+            return Err(anyhow::anyhow!(e));
+        }
+    };
+    let status = response.status();
+    let code = status.as_u16();
+    let body_text = response.text().await.unwrap_or_default();
+
+    if let Some(l) = ledger {
+        let err = if status.is_success() {
+            None
+        } else {
+            Some(format!("HTTP {}", code))
+        };
+        let _ = l.append_transport_http(
+            "researcher",
+            &payload_json,
+            &body_text,
+            Some(code),
+            err.as_deref(),
+        );
+    }
+
+    if !status.is_success() {
+        anyhow::bail!("researcher HTTP {}: {}", code, trim_line(&body_text, 200));
     }
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod adk_integration;
 pub mod agent_conversation_loop;
 pub mod agent_entities;
 pub mod app;
+pub mod event_ledger;
 pub mod http_client;
 pub mod reproducibility;
 


### PR DESCRIPTION
implemented for the append-only event ledger ([Issue #2](https://github.com/atomic-media-studio/arp/issues/2)):

New module: src/event_ledger.rs
EventEnvelope — experiment_id, run_id, monotonic event_id, event_type, timestamp, optional node_global_id / model, input_hash / output_hash (SHA-256 hex), plus payload (serde_json::Value).
EventLedger — append-only events.jsonl under runs/<experiment_id>/<run_id>/, mutex-protected writer, per-type counts, transport ok/fail counters, first/last timestamps.
try_finalize_run_stopped — single system.run_stopped + summary.json + flush (idempotent via finalized flag).
write_run_bundle_zip — zips manifest.json, events.jsonl, summary.json when present.
sha256_hex + unit test for the empty-string digest.
Dependencies
sha2, zip (deflate) in Cargo.toml.
Lifecycle
run_graph: after a successful persist_active_manifest, opens a ledger and records system.run_started. If there are no eligible workers, try_finalize_run_stopped("no_eligible_conversation_workers") runs immediately.
stop_graph: event_ledger.take() + try_finalize_run_stopped("graph_stopped").
Last conversation loop (when the shared loop counter hits zero): try_finalize_run_stopped("conversation_loops_finished") (no duplicate stop if already finalized).
HTTP (http_client.rs)
Optional ledger: Option<&Arc<EventLedger>> on all send helpers.
transport.http lines on success and failure (including network errors before a status is available).
Non-2xx responses return Err (failures are visible in the ledger and to callers).
Conversation & sidecars (agent_conversation_loop.rs)
SidecarEvaluator / SidecarResearcher include global_id.
Events: dialogue.start, dialogue.turn, dialogue.end, dialogue.ollama_error, sidecar.*, plus sidecar Ollama failures; HTTP calls pass ledger.
UI (settings_panel.rs)
Run bundle (zip) path + Download Run Bundle → download_run_bundle_to_path (needs current_run_context and an on-disk run dir).
State (app.rs)
event_ledger: Option<Arc<EventLedger>>, bundle_export_path (default runs/run-bundle.zip).
cargo test passes (including the SHA-256 sanity check).